### PR TITLE
Enable GNOME 41 and 42

### DIFF
--- a/kitchentimer@blackjackshellac.ca/metadata.json
+++ b/kitchentimer@blackjackshellac.ca/metadata.json
@@ -5,7 +5,8 @@
   "shell-version": [
     "3.36",
     "3.38",
-	"40"
+    "40",
+    "41"	  
   ],
   "gettext-domain": "kitchen-timer-blackjackshellac",
   "settings-schema": "org.gnome.shell.extensions.kitchen-timer-blackjackshellac",

--- a/kitchentimer@blackjackshellac.ca/metadata.json
+++ b/kitchentimer@blackjackshellac.ca/metadata.json
@@ -6,7 +6,8 @@
     "3.36",
     "3.38",
     "40",
-    "41"	  
+    "41",
+    "42"
   ],
   "gettext-domain": "kitchen-timer-blackjackshellac",
   "settings-schema": "org.gnome.shell.extensions.kitchen-timer-blackjackshellac",


### PR DESCRIPTION
openSUSE Tumbleweed and other distros are already shipping GNOME 41 and
even GNOME 42. Simply adding these as supported versions in metadata.json
appears sufficient in our tests.

On the way fix a minor formatting issue in the version table.